### PR TITLE
Makes Refresh use buildwindow instead

### DIFF
--- a/Editor/Graph/Views/DlogEditorWindow.cs
+++ b/Editor/Graph/Views/DlogEditorWindow.cs
@@ -114,11 +114,7 @@ namespace DialogueGraph {
             }
 
             if (editorView == null) {
-                editorView = new EditorView(this, dlogObject) {
-                    name = "Dlog Graph",
-                    IsBlackboardVisible = dlogObject.IsBlackboardVisible
-                };
-                rootVisualElement.Add(editorView);
+                BuildWindow();
             }
 
             editorView.BuildGraph();


### PR DESCRIPTION
The code at line 117 in DlogEditorWindow.cs essentially did the same as BuildWindow with omission of setting windowEvents and calling Refresh. Although calling Refresh might not be as necessary the omission of windowEvents being set causes the Save Graph to stop function when you enter play mode and view the window again.