### PR TITLE
EditorView.DlogGraphObject null reference fix

### DIFF
--- a/Editor/Graph/Views/DlogEditorWindow.cs
+++ b/Editor/Graph/Views/DlogEditorWindow.cs
@@ -34,7 +34,7 @@ namespace DialogueGraph {
             rootVisualElement.Clear();
             Events = new DlogWindowEvents {SaveRequested = SaveAsset, SaveAsRequested = SaveAs, ShowInProjectRequested = ShowInProject};
 
-            editorView = new EditorView(this, GraphObject) {
+            editorView = new EditorView(this) {
                 name = "Dlog Graph",
                 IsBlackboardVisible = GraphObject.IsBlackboardVisible
             };
@@ -99,7 +99,7 @@ namespace DialogueGraph {
 
         public void SetDlogObject(DlogGraphObject dlogObject) {
             SelectedAssetGuid = dlogObject.AssetGuid;
-            this.GraphObject = dlogObject;
+            GraphObject = dlogObject;
         }
 
         public void Refresh() {

--- a/Editor/Graph/Views/DlogGraphView.cs
+++ b/Editor/Graph/Views/DlogGraphView.cs
@@ -12,7 +12,7 @@ namespace DialogueGraph {
         public DlogGraphData DlogGraph => EditorView.DlogObject.DlogGraph;
 
         public DlogGraphView(EditorView editorView) {
-            this.EditorView = editorView;
+            EditorView = editorView;
             RegisterCallback<DragUpdatedEvent>(OnDragUpdated);
             RegisterCallback<DragPerformEvent>(OnDragPerformed);
             serializeGraphElements = SerializeGraphElementsImpl;

--- a/Editor/Graph/Views/EditorView.cs
+++ b/Editor/Graph/Views/EditorView.cs
@@ -23,14 +23,13 @@ namespace DialogueGraph {
 
         public DlogEditorWindow EditorWindow { get; }
 
-        public DlogGraphObject DlogObject { get; }
+        public DlogGraphObject DlogObject => EditorWindow.GraphObject;
 
         public DlogGraphView GraphView { get; }
 
         public EdgeConnectorListener EdgeConnectorListener { get; }
 
-        public EditorView(DlogEditorWindow editorWindow, DlogGraphObject dlogObject) {
-            DlogObject = dlogObject;
+        public EditorView(DlogEditorWindow editorWindow) {
             EditorWindow = editorWindow;
             this.AddStyleSheet("Styles/Graph");
             
@@ -51,7 +50,7 @@ namespace DialogueGraph {
 
                 GUILayout.FlexibleSpace();
                 IsBlackboardVisible = GUILayout.Toggle(IsBlackboardVisible, "Blackboard", EditorStyles.toolbarButton);
-                dlogObject.IsBlackboardVisible = IsBlackboardVisible;
+                editorWindow.GraphObject.IsBlackboardVisible = IsBlackboardVisible;
 
                 GUILayout.EndHorizontal();
             });


### PR DESCRIPTION
`EditorView.DlogObject` at first contains the same reference as `DlogEditorWindow.GraphObject`, however when the `DlogEditorWindow.GraphObject` is null (the unity side of it) in update this will invoke `DlogEditorWindow.SetDlogObject()` however this doesn't update `EditorView.DlogObject`

In general I think it makes more sense for EditorView to only reference the GraphObject through the EditorWindow since the editorwindow "owns" the reference