### PR TITLE
GetCurrentActor NullreferenceException when no ActorData

### DIFF
--- a/Runtime/RuntimeDialogueGraph.cs
+++ b/Runtime/RuntimeDialogueGraph.cs
@@ -63,7 +63,7 @@ namespace DialogueGraph.Runtime {
 
         public ActorData GetCurrentActor() {
             var currentNode = DlogObject.NodeDictionary[currentNodeGuid];
-            if (currentNode.Type != NodeType.NPC) return null;
+            if (currentNode.Type != NodeType.NPC || string.IsNullOrEmpty(currentNode.ActorGuid)) return null;
             var currentNodeActorGuid = currentNode.ActorGuid;
             var actor = CurrentData.ActorData[CurrentData.ActorDataIndices[currentNodeActorGuid]];
             return actor;


### PR DESCRIPTION
GetCurrentActor should return null when checking for ActorData on an NPC node instead of hitting a nullreferenceexception
This should fix the issue mentioned in: #15 